### PR TITLE
Added support for sessionToken (AWS_SESSION_TOKEN)

### DIFF
--- a/index.js
+++ b/index.js
@@ -76,6 +76,7 @@ exports.createPresignedURL = function(method, host, path, service, payload, opti
   options = options || {};
   options.key = options.key || process.env.AWS_ACCESS_KEY_ID;
   options.secret = options.secret || process.env.AWS_SECRET_ACCESS_KEY;
+  options.sessionToken = options.sessionToken || process.env.AWS_SESSION_TOKEN;
   options.protocol = options.protocol || 'https';
   options.headers = options.headers || {};
   options.timestamp = options.timestamp || Date.now();
@@ -92,6 +93,9 @@ exports.createPresignedURL = function(method, host, path, service, payload, opti
   query['X-Amz-Date'] = toTime(options.timestamp);
   query['X-Amz-Expires'] = options.expires;
   query['X-Amz-SignedHeaders'] = exports.createSignedHeaders(options.headers);
+  if (options.sessionToken) {
+    query['X-Amz-Security-Token'] = options.sessionToken;
+  }
 
   var canonicalRequest = exports.createCanonicalRequest(method, path, query, options.headers, payload);
   var stringToSign = exports.createStringToSign(options.timestamp, options.region, service, canonicalRequest);

--- a/test.js
+++ b/test.js
@@ -8,6 +8,7 @@ describe('aws-signature-v4', function() {
   // taken from the AWS documentation example code
   var accessKey = 'AKIAIOSFODNN7EXAMPLE';
   var secretKey = 'wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY';
+  var sessionToken = 'EXAMPLESESSION';
   var exampleTime = Date.parse('Fri, 24 May 2013 00:00:00 GMT');
   var canonicalRequest = aws.createCanonicalRequest('GET', '/test.txt', {
       'X-Amz-Algorithm': 'AWS4-HMAC-SHA256',
@@ -74,5 +75,16 @@ describe('aws-signature-v4', function() {
       query: 'key=value&key2=value2'
     });
     assert.equal(presignedUrlWithQuery, 'https://examplebucket.s3.amazonaws.com/test.txt?key=value&key2=value2&X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAIOSFODNN7EXAMPLE%2F20130524%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20130524T000000Z&X-Amz-Expires=86400&X-Amz-SignedHeaders=host&X-Amz-Signature=9441992768076e59f7162b6a5dd3782cddf270398d8508408386af62eed5570c');
+  });
+
+  it('should generate a presigned url with security token', function() {
+    var presignedUrlWithSecurityToken = aws.createPresignedS3URL('test.txt', {
+      key: accessKey,
+      secret: secretKey,
+      bucket: 'examplebucket',
+      timestamp: exampleTime,
+      sessionToken: sessionToken,
+    });
+    assert.equal(presignedUrlWithSecurityToken, 'https://examplebucket.s3.amazonaws.com/test.txt?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAIOSFODNN7EXAMPLE%2F20130524%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20130524T000000Z&X-Amz-Expires=86400&X-Amz-SignedHeaders=host&X-Amz-Security-Token=EXAMPLESESSION&X-Amz-Signature=12abb65becb4cfbac48bfdd9eb3178408ff6fd7f470505f4baf3dcad7088253f');
   });
 });


### PR DESCRIPTION
This PR proposes an implementation that allows `sessionToken` to be provided at `options`. By default it is set to be `process.env.AWS_SESSION_TOKEN`. This is useful in some environments (e.g. Lambda deployments), where using `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_TOKEN` alone is not enough to produce a valid request.

Reference: [v4 implementation from latest (v2.188.0 as of writing) version of `aws-sdk`](https://github.com/aws/aws-sdk-js/blob/v2.188.0/lib/signers/v4.js)