### PR TITLE
Add session token as the last query parameter

### DIFF
--- a/index.js
+++ b/index.js
@@ -93,14 +93,16 @@ exports.createPresignedURL = function(method, host, path, service, payload, opti
   query['X-Amz-Date'] = toTime(options.timestamp);
   query['X-Amz-Expires'] = options.expires;
   query['X-Amz-SignedHeaders'] = exports.createSignedHeaders(options.headers);
-  if (options.sessionToken) {
-    query['X-Amz-Security-Token'] = options.sessionToken;
-  }
 
   var canonicalRequest = exports.createCanonicalRequest(method, path, query, options.headers, payload);
   var stringToSign = exports.createStringToSign(options.timestamp, options.region, service, canonicalRequest);
   var signature = exports.createSignature(options.secret, options.timestamp, options.region, service, stringToSign);
   query['X-Amz-Signature'] = signature;
+
+  if (options.sessionToken) {
+    query['X-Amz-Security-Token'] = options.sessionToken;
+  }
+
   return options.protocol + '://' + host + path + '?' + querystring.stringify(query);
 };
 

--- a/test.js
+++ b/test.js
@@ -77,7 +77,7 @@ describe('aws-signature-v4', function() {
     assert.equal(presignedUrlWithQuery, 'https://examplebucket.s3.amazonaws.com/test.txt?key=value&key2=value2&X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAIOSFODNN7EXAMPLE%2F20130524%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20130524T000000Z&X-Amz-Expires=86400&X-Amz-SignedHeaders=host&X-Amz-Signature=9441992768076e59f7162b6a5dd3782cddf270398d8508408386af62eed5570c');
   });
 
-  it('should generate a presigned url with security token', function() {
+  it('should generate a presigned url with security token, and security token should be the last parameter', function() {
     var presignedUrlWithSecurityToken = aws.createPresignedS3URL('test.txt', {
       key: accessKey,
       secret: secretKey,
@@ -85,6 +85,6 @@ describe('aws-signature-v4', function() {
       timestamp: exampleTime,
       sessionToken: sessionToken,
     });
-    assert.equal(presignedUrlWithSecurityToken, 'https://examplebucket.s3.amazonaws.com/test.txt?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAIOSFODNN7EXAMPLE%2F20130524%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20130524T000000Z&X-Amz-Expires=86400&X-Amz-SignedHeaders=host&X-Amz-Security-Token=EXAMPLESESSION&X-Amz-Signature=12abb65becb4cfbac48bfdd9eb3178408ff6fd7f470505f4baf3dcad7088253f');
+    assert.equal(presignedUrlWithSecurityToken, 'https://examplebucket.s3.amazonaws.com/test.txt?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAIOSFODNN7EXAMPLE%2F20130524%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20130524T000000Z&X-Amz-Expires=86400&X-Amz-SignedHeaders=host&X-Amz-Signature=aeeed9bbccd4d02ee5c0109b86d86835f995330da4c265957d157751f604d404&X-Amz-Security-Token=EXAMPLESESSION');
   });
 });


### PR DESCRIPTION
Some AWS services, like IoT (specifically the MQTT message queues), won't accept token requests unless the token is the final query parameter. This is not always documented, and leads to somewhat frustrating debugging session as you can imagine :)

AWS indicates this in [their docs](https://docs.aws.amazon.com/general/latest/gr/sigv4-create-canonical-request.html):

"For other services, you add the X-Amz-Security-Token parameter at the end, after you calculate the signature. For details, see the API reference documentation for that service."

Adding it as the last `query` key is a little silly, but should work in most runtimes and definitely won't make anything worse. A more complete but ugly solution is to manually encode the security token and slap it at the end of the URL.